### PR TITLE
fix bad ProcDict generation for *_training

### DIFF
--- a/common/makeSampleList.py
+++ b/common/makeSampleList.py
@@ -187,7 +187,7 @@ class MakeSampleList:
                                            'stdhep', extension)
                 if training:
                     yamldir_lhe = os.path.join(self.para.yamldir, 'stdhep',
-                                               extension+'training')
+                                               extension+'/training')
 
             yaml_reco = os.path.join(yamldir_reco, l, 'merge.yaml')
             if not ut.file_exist(yaml_reco):


### PR DESCRIPTION
cron jobs were systematically failing to find information about *_training production due t o a bug in the "LHE yaml" path definition, e.g. looking for

`/afs/cern.ch/work/f/fccsw/public/FCCDicts/yaml/FCCee/stdhep/winter2023training/wzp6_ee_eeH_ecm365/merge.yaml`

instead of 

`/afs/cern.ch/work/f/fccsw/public/FCCDicts/yaml/FCCee/stdhep/winter2023/training/wzp6_ee_eeH_ecm365/merge.yaml`

This PR should fix this behaviour, and allow for proper ProcDict to be retrieved by analysers

