### PR TITLE
Add Herwig and Sherpa direct production

### DIFF
--- a/bin/run.py
+++ b/bin/run.py
@@ -30,7 +30,7 @@ def main():
     jobTypeGroup.add_argument("--sample", action='store_true', help="make the proc dict" )
 
     sendjobGroup = parser.add_argument_group('type of jobs to send')
-    sendjobGroup.add_argument('--type', type=str, required = '--send' in sys.argv and '--reco'  in sys.argv , help='type of jobs to send', choices = ['lhep8','p8','stdhep'])
+    sendjobGroup.add_argument('--type', type=str, required = '--send' in sys.argv and '--reco'  in sys.argv , help='type of jobs to send', choices = ['lhep8','p8','stdhep','herwig','sherpa'])
     sendjobGroup.add_argument('--typelhe', type=str, required = '--send' in sys.argv and '--LHE'  in sys.argv , help='type of jobs to send', choices = ['gp_mg','gp_pw','mg','kkmc'])
     sendjobGroup.add_argument('--typestdhep', type=str, required = '--send' in sys.argv and '--STDHEP'  in sys.argv , help='type of jobs to send', choices = ['wzp6'])
 
@@ -123,6 +123,12 @@ def main():
             if key[0:5]=='kkmc_': newkey='kkmcp8_'+key[5:]
             for v in value:
                 processlist.append("%s_%s"%(newkey,v))
+    if (args.reco and args.type=="herwig") or args.check or args.checkeos or args.clean or args.cleanold or args.merge or args.remove:
+        for key, value in para.herwiglist.items():
+            processlist.append(key)
+    if (args.reco and args.type=="sherpa") or args.check or args.checkeos or args.clean or args.cleanold or args.merge or args.remove:
+        for key, value in para.sherpalist.items():
+            processlist.append(key)
     if args.LHE or args.STDHEP or args.check or args.checkeos or args.clean or args.merge or args.reco:
         for key, value in para.gridpacklist.items():
             processlist.append(key)
@@ -307,6 +313,16 @@ def main():
                 import EventProducer.bin.send_fromstdhep as sstdhep
                 sendstdhep = sstdhep.send_fromstdhep(args.numJobs,args.numEvents, args.process, args.lsf, args.condor, args.local, args.queue, args.priority, args.ncpus, para, version, detector, args.decay)
                 sendstdhep.send(args.force)
+            elif sendOpt == 'herwig':
+                print('preparing to send FCCSW jobs from Herwig (HepMC2) directly')
+                import EventProducer.bin.send_herwig as sherwig
+                sendherwig = sherwig.send_herwig(args.numJobs,args.numEvents, args.process, args.lsf, args.condor, args.local, args.queue, args.priority, args.ncpus, para, version, training, detector, args.customEDM4HEPOutput)
+                sendherwig.send()
+            elif sendOpt == 'sherpa':
+                print('preparing to send FCCSW jobs from Sherpa (HepMC3) directly')
+                import EventProducer.bin.send_sherpa as ssherpa
+                sendsherpa = ssherpa.send_sherpa(args.numJobs,args.numEvents, args.process, args.lsf, args.condor, args.local, args.queue, args.priority, args.ncpus, para, version, training, detector, args.customEDM4HEPOutput)
+                sendsherpa.send()
 
     elif args.web:
         import EventProducer.common.printer as prt

--- a/bin/send_herwig.py
+++ b/bin/send_herwig.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+import os, sys
+import subprocess
+import time
+import EventProducer.common.utils as ut
+import EventProducer.common.makeyaml as my
+
+class send_herwig():
+
+#__________________________________________________________
+    def __init__(self, njobs, events, process, islsf, iscondor, islocal, queue, priority, ncpus, para, version, training, detector, custom_edm4hep_config):
+        self.njobs    = njobs
+        self.events   = events
+        self.process  = process
+        self.islsf    = islsf
+        self.iscondor = iscondor
+        self.islocal  = islocal
+        self.queue    = queue
+        self.priority = priority
+        self.ncpus    = ncpus
+        self.user     = os.environ['USER']
+        self.para     = para
+        self.version  = version
+        self.training = training
+        self.detector = detector
+        self.custom_edm4hep_config = custom_edm4hep_config
+
+#__________________________________________________________
+    def send(self):
+
+        Dir = os.getcwd()
+        nbjobsSub=0
+
+        hwlist=self.para.herwiglist
+        outdir='%s%s/%s/'%(self.para.delphes_dir,self.version,self.detector)
+        try:
+            hwlist[self.process]
+        except KeyError:
+            print ('process %s does not exist in herwiglist, exit'%self.process)
+            sys.exit(3)
+
+        acctype='FCC'
+        if 'FCCee' in self.para.module_name:  acctype='FCCee'
+
+        logdir=Dir+"/BatchOutputs/%s/%s/%s/%s/"%(acctype,self.version,self.detector,self.process)
+        if not ut.dir_exist(logdir):
+            os.system("mkdir -p %s"%logdir)
+
+        if not self.islocal:
+            yamldir = '%s/%s/%s/%s'%(self.para.yamldir,self.version,self.detector,self.process)
+            if not ut.dir_exist(yamldir):
+                os.system("mkdir -p %s"%yamldir)
+
+        # Delphes detector card + edm4hep output config of the campaign
+        delphescards_base = '%scard_%s.tcl'%(self.para.delphescards_dir,self.detector)
+        delphescards_base = delphescards_base.replace('_VERSION_',self.version)
+        if ut.file_exist(delphescards_base)==False:
+            print ('delphes card does not exist: ',delphescards_base,' , exit')
+            sys.exit(3)
+
+        # Herwig input card for this process
+        herwigcard = '%s%s.in'%(self.para.herwigcards_dir,self.process)
+        herwigcard = herwigcard.replace('_VERSION_',self.version)
+        if ut.file_exist(herwigcard)==False:
+            print ('herwig card does not exist: ',herwigcard,' , exit')
+            sys.exit(3)
+
+        if self.islsf==False and self.iscondor==False and self.islocal==False:
+            print ("Submit issue : LSF nor CONDOR not Local flag defined !!!")
+            sys.exit(3)
+
+        condor_file_str=''
+        while nbjobsSub<self.njobs:
+
+            uid = ut.getuid2()
+            if self.training: uid = ut.getuidtraining()
+            if not self.islocal:
+                myyaml = my.makeyaml(yamldir, uid)
+                if not myyaml:
+                    print ('job %s already exists'%uid)
+                    continue
+                outfile='%s/%s/events_%s.root'%(outdir,self.process,uid)
+                if ut.file_exist(outfile):
+                    print ('file %s already exist on eos, continue'%outfile)
+                    continue
+
+            if self.islocal:
+                outfile='%s/events_%s.root'%(logdir,uid)
+                if ut.file_exist(outfile):
+                    print ('file %s already locally exist, continue'%outfile)
+                    continue
+
+            frunname = 'job%s.sh'%(uid)
+            frunfull = '%s/%s'%(logdir,frunname)
+            print ('frunname  ',frunname)
+            print ('frunfull  ',frunfull)
+            frun = None
+            try:
+                frun = open(frunfull, 'w')
+            except IOError as e:
+                print ("I/O error({0}): {1}".format(e.errno, e.strerror))
+                time.sleep(10)
+                frun = open(frunfull, 'w')
+            subprocess.getstatusoutput('chmod 777 %s'%(frunfull))
+
+            proc_trunc = self.process[:37] + ( self.process[37:] and 'More')
+            eoscopy = 'python /afs/cern.ch/work/f/fccsw/public/FCCutils/eoscopy.py'
+
+            frun.write('#!/bin/bash\n')
+            frun.write('unset LD_LIBRARY_PATH PYTHONHOME PYTHONPATH\n')
+            frun.write('mkdir job%s_%s\n'%(uid,proc_trunc))
+            frun.write('cd job%s_%s\n'%(uid,proc_trunc))
+            frun.write('export EOS_MGM_URL="root://eospublic.cern.ch"\n')
+            if self.islocal==False:
+                frun.write('mkdir -p %s/%s\n'%(outdir,self.process))
+
+            # single stack for the whole job (the campaign stack ships Herwig AND k4SimDelphes)
+            frun.write('source %s\n'%(self.para.prodTag[self.version]))
+            # fail the job on any error so condor retries it (exit code otherwise masked by the final rm)
+            frun.write('set -e\n')
+            # Herwig/ThePEG runtime libs are not on LD_LIBRARY_PATH in the stack
+            frun.write('export LD_LIBRARY_PATH="$(thepeg-config --libdir):$(herwig-config --libdir):$LD_LIBRARY_PATH"\n')
+            # Herwig instantiates a default PDF even for e+e- -> point LHAPDF at the shipped sets
+            frun.write('for d in /cvmfs/sw-nightlies.hsf.org/key4hep/releases/*/x86_64-almalinux9-*-opt/lhapdfsets/*/share/lhapdfsets; do [ -d "$d" ] && export LHAPDF_DATA_PATH="$d" && break; done\n')
+
+            # generation: Herwig read+run -> events.hepmc (HepMC2 ascii, filename set in the card)
+            frun.write('%s %s card.in\n'%(eoscopy,herwigcard))
+            # snippets/HepMC.in caps the written events at PrintEvent=10000 -> raise it to the
+            # requested number (insert before saverun, i.e. after the snippet is read)
+            frun.write('sed -i "/^saverun/i set /Herwig/Analysis/HepMC:PrintEvent %i" card.in\n'%(self.events))
+            frun.write('Herwig read card.in\n')
+            # seed as plain int: a leading zero in the uid is rejected by Herwig ('invalid numeric value')
+            frun.write('Herwig run %s.run -N %i -s %i\n'%(self.process,self.events,int(uid)))
+
+            # reco: HepMC2 -> EDM4hep in one step (Herwig writes HepMC2; the HepMC3
+            # reader would silently produce zero events on a HepMC2 file)
+            frun.write('%s %s card.tcl\n'%(eoscopy,delphescards_base))
+            if self.custom_edm4hep_config:
+                frun.write('cp %s edm4hep.tcl\n'%(self.custom_edm4hep_config))
+            else:
+                frun.write('%s /eos/experiment/fcc/ee/generation/FCC-config/%s/FCCee/Delphes/edm4hep_%s.tcl edm4hep.tcl\n'%(eoscopy,self.version,self.detector))
+            frun.write('DelphesHepMC2_EDM4HEP card.tcl edm4hep.tcl events_%s.root events.hepmc\n'%(uid))
+
+            frun.write('%s events_%s.root %s\n'%(eoscopy,uid,outfile))
+            frun.write('cd ..\n')
+            frun.write('rm -rf job%s_%s\n'%(uid,proc_trunc))
+            frun.close()
+
+            if self.islsf==True :
+              cmdBatch="bsub -M 2000000 -R \"pool=20000\" -q %s -o %s -cwd %s %s" %(self.queue, logdir+'/job%s/'%(uid),logdir+'/job%s/'%(uid),frunfull)
+              job,batchid=ut.SubmitToLsf(cmdBatch,10,"%i/%i"%(nbjobsSub,self.njobs))
+              nbjobsSub+=job
+            elif self.iscondor==True :
+              condor_file_str+=frunfull+" "
+              nbjobsSub+=1
+            elif self.islocal==True:
+                print ('will run locally')
+                nbjobsSub+=1
+                os.system('%s'%frunfull)
+
+        if self.iscondor==True :
+            condor_file_str=condor_file_str.replace("//","/")
+            frunname_condor = 'job_desc_herwig_%s.cfg'%(self.process)
+            frunfull_condor = '%s/%s'%(logdir,frunname_condor)
+            frun_condor = None
+            try:
+                frun_condor = open(frunfull_condor, 'w')
+            except IOError as e:
+                print ("I/O error({0}): {1}".format(e.errno, e.strerror))
+                time.sleep(10)
+                frun_condor = open(frunfull_condor, 'w')
+            subprocess.getstatusoutput('chmod 777 %s'%frunfull_condor)
+
+            frun_condor.write('executable     = $(filename)\n')
+            frun_condor.write('Log            = %s/condor_job.%s.$(ClusterId).log\n'%(logdir,str(uid)))
+            frun_condor.write('Output         = %s/condor_job.%s.$(ClusterId).$(ProcId).out\n'%(logdir,str(uid)))
+            frun_condor.write('Error          = %s/condor_job.%s.$(ClusterId).$(ProcId).error\n'%(logdir,str(uid)))
+            frun_condor.write('getenv         = True\n')
+            frun_condor.write('environment    = "LS_SUBCWD=%s"\n'%logdir)
+            frun_condor.write('requirements    = ( (OpSysAndVer =?= "AlmaLinux9") && (Machine =!= LastRemoteHost) && (TARGET.has_avx2 =?= True) )\n')
+            frun_condor.write('on_exit_remove = (ExitBySignal == False) && (ExitCode == 0)\n')
+            frun_condor.write('max_retries    = 3\n')
+            frun_condor.write('+JobFlavour    = "%s"\n'%self.queue)
+            frun_condor.write('+AccountingGroup = "%s"\n'%self.priority)
+            frun_condor.write('RequestCpus = %s\n'%self.ncpus)
+            frun_condor.write('queue filename matching files %s\n'%condor_file_str)
+            frun_condor.close()
+
+            nbjobsSub=0
+            cmdBatch="condor_submit %s"%frunfull_condor
+            print (cmdBatch)
+            job=ut.SubmitToCondor(cmdBatch,10,"%i/%i"%(nbjobsSub,self.njobs))
+            nbjobsSub+=job
+
+        print ('succesfully sent %i  job(s)'%nbjobsSub)

--- a/bin/send_sherpa.py
+++ b/bin/send_sherpa.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+import os, sys
+import subprocess
+import time
+import EventProducer.common.utils as ut
+import EventProducer.common.makeyaml as my
+
+class send_sherpa():
+
+#__________________________________________________________
+    def __init__(self, njobs, events, process, islsf, iscondor, islocal, queue, priority, ncpus, para, version, training, detector, custom_edm4hep_config):
+        self.njobs    = njobs
+        self.events   = events
+        self.process  = process
+        self.islsf    = islsf
+        self.iscondor = iscondor
+        self.islocal  = islocal
+        self.queue    = queue
+        self.priority = priority
+        self.ncpus    = ncpus
+        self.user     = os.environ['USER']
+        self.para     = para
+        self.version  = version
+        self.training = training
+        self.detector = detector
+        self.custom_edm4hep_config = custom_edm4hep_config
+
+#__________________________________________________________
+    def send(self):
+
+        Dir = os.getcwd()
+        nbjobsSub=0
+
+        shlist=self.para.sherpalist
+        outdir='%s%s/%s/'%(self.para.delphes_dir,self.version,self.detector)
+        try:
+            shlist[self.process]
+        except KeyError:
+            print ('process %s does not exist in sherpalist, exit'%self.process)
+            sys.exit(3)
+
+        acctype='FCC'
+        if 'FCCee' in self.para.module_name:  acctype='FCCee'
+
+        logdir=Dir+"/BatchOutputs/%s/%s/%s/%s/"%(acctype,self.version,self.detector,self.process)
+        if not ut.dir_exist(logdir):
+            os.system("mkdir -p %s"%logdir)
+
+        if not self.islocal:
+            yamldir = '%s/%s/%s/%s'%(self.para.yamldir,self.version,self.detector,self.process)
+            if not ut.dir_exist(yamldir):
+                os.system("mkdir -p %s"%yamldir)
+
+        # Delphes detector card + edm4hep output config of the campaign
+        delphescards_base = '%scard_%s.tcl'%(self.para.delphescards_dir,self.detector)
+        delphescards_base = delphescards_base.replace('_VERSION_',self.version)
+        if ut.file_exist(delphescards_base)==False:
+            print ('delphes card does not exist: ',delphescards_base,' , exit')
+            sys.exit(3)
+
+        # Sherpa input card for this process
+        sherpacard = '%s%s.yaml'%(self.para.sherpacards_dir,self.process)
+        sherpacard = sherpacard.replace('_VERSION_',self.version)
+        if ut.file_exist(sherpacard)==False:
+            print ('sherpa card does not exist: ',sherpacard,' , exit')
+            sys.exit(3)
+
+        if self.islsf==False and self.iscondor==False and self.islocal==False:
+            print ("Submit issue : LSF nor CONDOR not Local flag defined !!!")
+            sys.exit(3)
+
+        condor_file_str=''
+        while nbjobsSub<self.njobs:
+
+            uid = ut.getuid2()
+            if self.training: uid = ut.getuidtraining()
+            if not self.islocal:
+                myyaml = my.makeyaml(yamldir, uid)
+                if not myyaml:
+                    print ('job %s already exists'%uid)
+                    continue
+                outfile='%s/%s/events_%s.root'%(outdir,self.process,uid)
+                if ut.file_exist(outfile):
+                    print ('file %s already exist on eos, continue'%outfile)
+                    continue
+
+            if self.islocal:
+                outfile='%s/events_%s.root'%(logdir,uid)
+                if ut.file_exist(outfile):
+                    print ('file %s already locally exist, continue'%outfile)
+                    continue
+
+            frunname = 'job%s.sh'%(uid)
+            frunfull = '%s/%s'%(logdir,frunname)
+            print ('frunname  ',frunname)
+            print ('frunfull  ',frunfull)
+            frun = None
+            try:
+                frun = open(frunfull, 'w')
+            except IOError as e:
+                print ("I/O error({0}): {1}".format(e.errno, e.strerror))
+                time.sleep(10)
+                frun = open(frunfull, 'w')
+            subprocess.getstatusoutput('chmod 777 %s'%(frunfull))
+
+            proc_trunc = self.process[:37] + ( self.process[37:] and 'More')
+            eoscopy = 'python /afs/cern.ch/work/f/fccsw/public/FCCutils/eoscopy.py'
+
+            frun.write('#!/bin/bash\n')
+            frun.write('unset LD_LIBRARY_PATH PYTHONHOME PYTHONPATH\n')
+            frun.write('mkdir job%s_%s\n'%(uid,proc_trunc))
+            frun.write('cd job%s_%s\n'%(uid,proc_trunc))
+            frun.write('export EOS_MGM_URL="root://eospublic.cern.ch"\n')
+            if self.islocal==False:
+                frun.write('mkdir -p %s/%s\n'%(outdir,self.process))
+
+            # single stack for the whole job (the campaign stack ships Sherpa AND k4SimDelphes)
+            frun.write('source %s\n'%(self.para.prodTag[self.version]))
+            # fail the job on any error so condor retries it (exit code otherwise masked by the final rm)
+            frun.write('set -e\n')
+            # Sherpa needs an LHAPDF sets dir to initialise even for e+e- (unused by the ee ME)
+            frun.write('for d in /cvmfs/sw-nightlies.hsf.org/key4hep/releases/*/x86_64-almalinux9-*-opt/lhapdfsets/*/share/lhapdfsets; do [ -d "$d" ] && export LHAPDF_DATA_PATH="$d" && break; done\n')
+
+            # generation: Sherpa -> events.hepmc (HepMC3 ascii, filename set in the card);
+            # the first pass integrates the ME (Results/ grids), then generates -- one call does both
+            frun.write('%s %s card.yaml\n'%(eoscopy,sherpacard))
+            # seed as plain int (avoid leading-zero uids being parsed as invalid/octal)
+            frun.write('Sherpa -f card.yaml -e %i -R %i\n'%(self.events,int(uid)))
+
+            # reco: HepMC3 -> EDM4hep in one step (Sherpa writes HepMC3; the HepMC2
+            # reader would silently produce zero events on a HepMC3 file)
+            frun.write('%s %s card.tcl\n'%(eoscopy,delphescards_base))
+            if self.custom_edm4hep_config:
+                frun.write('cp %s edm4hep.tcl\n'%(self.custom_edm4hep_config))
+            else:
+                frun.write('%s /eos/experiment/fcc/ee/generation/FCC-config/%s/FCCee/Delphes/edm4hep_%s.tcl edm4hep.tcl\n'%(eoscopy,self.version,self.detector))
+            frun.write('DelphesHepMC3_EDM4HEP card.tcl edm4hep.tcl events_%s.root events.hepmc\n'%(uid))
+
+            frun.write('%s events_%s.root %s\n'%(eoscopy,uid,outfile))
+            frun.write('cd ..\n')
+            frun.write('rm -rf job%s_%s\n'%(uid,proc_trunc))
+            frun.close()
+
+            if self.islsf==True :
+              cmdBatch="bsub -M 2000000 -R \"pool=20000\" -q %s -o %s -cwd %s %s" %(self.queue, logdir+'/job%s/'%(uid),logdir+'/job%s/'%(uid),frunfull)
+              job,batchid=ut.SubmitToLsf(cmdBatch,10,"%i/%i"%(nbjobsSub,self.njobs))
+              nbjobsSub+=job
+            elif self.iscondor==True :
+              condor_file_str+=frunfull+" "
+              nbjobsSub+=1
+            elif self.islocal==True:
+                print ('will run locally')
+                nbjobsSub+=1
+                os.system('%s'%frunfull)
+
+        if self.iscondor==True :
+            condor_file_str=condor_file_str.replace("//","/")
+            frunname_condor = 'job_desc_sherpa_%s.cfg'%(self.process)
+            frunfull_condor = '%s/%s'%(logdir,frunname_condor)
+            frun_condor = None
+            try:
+                frun_condor = open(frunfull_condor, 'w')
+            except IOError as e:
+                print ("I/O error({0}): {1}".format(e.errno, e.strerror))
+                time.sleep(10)
+                frun_condor = open(frunfull_condor, 'w')
+            subprocess.getstatusoutput('chmod 777 %s'%frunfull_condor)
+
+            frun_condor.write('executable     = $(filename)\n')
+            frun_condor.write('Log            = %s/condor_job.%s.$(ClusterId).log\n'%(logdir,str(uid)))
+            frun_condor.write('Output         = %s/condor_job.%s.$(ClusterId).$(ProcId).out\n'%(logdir,str(uid)))
+            frun_condor.write('Error          = %s/condor_job.%s.$(ClusterId).$(ProcId).error\n'%(logdir,str(uid)))
+            frun_condor.write('getenv         = True\n')
+            frun_condor.write('environment    = "LS_SUBCWD=%s"\n'%logdir)
+            frun_condor.write('requirements    = ( (OpSysAndVer =?= "AlmaLinux9") && (Machine =!= LastRemoteHost) && (TARGET.has_avx2 =?= True) )\n')
+            frun_condor.write('on_exit_remove = (ExitBySignal == False) && (ExitCode == 0)\n')
+            frun_condor.write('max_retries    = 3\n')
+            frun_condor.write('+JobFlavour    = "%s"\n'%self.queue)
+            frun_condor.write('+AccountingGroup = "%s"\n'%self.priority)
+            frun_condor.write('RequestCpus = %s\n'%self.ncpus)
+            frun_condor.write('queue filename matching files %s\n'%condor_file_str)
+            frun_condor.close()
+
+            nbjobsSub=0
+            cmdBatch="condor_submit %s"%frunfull_condor
+            print (cmdBatch)
+            job=ut.SubmitToCondor(cmdBatch,10,"%i/%i"%(nbjobsSub,self.njobs))
+            nbjobsSub+=job
+
+        print ('succesfully sent %i  job(s)'%nbjobsSub)

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -104,6 +104,19 @@ detectors = [
 pythialist = {
     'dummy':['NOT REGISTERED IN param_FCCee', 'NOT REGISTERED IN param_FCCee', '', '-9999', '-9999', '-9999'],
 
+    # pre_summer2026 Z->qq flavour-tagging samples; _cylinder = old winter2023 long-lived
+    # convention (limitCylinder), bare = proper-lifetime cut (tau0Max=100, as Herwig/Sherpa)
+    'p8_ee_dd_ecm91p2':['Z/Gamma* ecm=91.188GeV to dd','inclusive decays','','6655.04','1.0','1.0'],
+    'p8_ee_uu_ecm91p2':['Z/Gamma* ecm=91.188GeV to uu','inclusive decays','','5215.46','1.0','1.0'],
+    'p8_ee_ss_ecm91p2':['Z/Gamma* ecm=91.188GeV to ss','inclusive decays','','5215.46','1.0','1.0'],
+    'p8_ee_cc_ecm91p2':['Z/Gamma* ecm=91.188GeV to cc','inclusive decays','','5215.46','1.0','1.0'],
+    'p8_ee_bb_ecm91p2':['Z/Gamma* ecm=91.188GeV to bb','inclusive decays','','6645.46','1.0','1.0'],
+    'p8_ee_dd_ecm91p2_cylinder':['Z/Gamma* ecm=91.188GeV to dd','cylinder long-lived convention','','6655.04','1.0','1.0'],
+    'p8_ee_uu_ecm91p2_cylinder':['Z/Gamma* ecm=91.188GeV to uu','cylinder long-lived convention','','5215.46','1.0','1.0'],
+    'p8_ee_ss_ecm91p2_cylinder':['Z/Gamma* ecm=91.188GeV to ss','cylinder long-lived convention','','5215.46','1.0','1.0'],
+    'p8_ee_cc_ecm91p2_cylinder':['Z/Gamma* ecm=91.188GeV to cc','cylinder long-lived convention','','5215.46','1.0','1.0'],
+    'p8_ee_bb_ecm91p2_cylinder':['Z/Gamma* ecm=91.188GeV to bb','cylinder long-lived convention','','6645.46','1.0','1.0'],
+
     'p8_ee_ZH_Znunu_Hgg_ecm240':['ZH ecm=240GeV','Z->nunu, H->gg','','0.201868','1.0','1.0'],             #    Pythia 8.303, noBES (Used 0.201037 before)
     'p8_ee_ZH_Znunu_Hbb_ecm240':['ZH ecm=240GeV','Z->nunu, H->bb','','0.201868','1.0','1.0'],             #    Pythia 8.303, noBES (Used 0.201037 before)
     'p8_ee_ZH_Znunu_Hcc_ecm240':['ZH ecm=240GeV','Z->nunu, H->cc','','0.201868','1.0','1.0'],             #    Pythia 8.303, noBES (Used 0.201037 before)

--- a/config/param_FCCee.py
+++ b/config/param_FCCee.py
@@ -76,6 +76,10 @@ pythiacards_dir  = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/Pythia8
 evtgencards_dir  = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/EvtGen/"
 ##where the WHIZARD cards are stored
 whizardcards_dir = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/Whizard/"
+##where the HERWIG cards are stored
+herwigcards_dir = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/Herwig/"
+##where the SHERPA cards are stored
+sherpacards_dir = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/Sherpa/"
 ##where the KKMC cards are stored
 kkmccards_dir = eosbaseinputdir+"FCC-config/_VERSION_/FCCee/Generator/KKMC/"
 # /cvmfs/fcc.cern.ch/sw/latest/setup.sh
@@ -503,6 +507,26 @@ branching_ratios = {
 
 }
 
+
+# list of processes generated with Herwig directly (Herwig -> HepMC2 -> Delphes EDM4hep, single job)
+# xsec consistent with the pythialist Zqq entries (Zud 11870.5 split: dd down-type, uu up-type ~ cc)
+herwiglist = {
+    'hw_ee_dd_ecm91p2':['Z/Gamma* ecm=91.188GeV to dd (Herwig 7.3)','','','6655.04','1.0','1.0'],
+    'hw_ee_uu_ecm91p2':['Z/Gamma* ecm=91.188GeV to uu (Herwig 7.3)','','','5215.46','1.0','1.0'],
+    'hw_ee_ss_ecm91p2':['Z/Gamma* ecm=91.188GeV to ss (Herwig 7.3)','','','5215.46','1.0','1.0'],
+    'hw_ee_cc_ecm91p2':['Z/Gamma* ecm=91.188GeV to cc (Herwig 7.3)','','','5215.46','1.0','1.0'],
+    'hw_ee_bb_ecm91p2':['Z/Gamma* ecm=91.188GeV to bb (Herwig 7.3)','','','6645.46','1.0','1.0'],
+}
+
+# list of processes generated with Sherpa directly (Sherpa -> HepMC3 -> Delphes EDM4hep, single job)
+# xsec consistent with the pythialist Zqq entries (Zud 11870.5 split: dd down-type, uu up-type ~ cc)
+sherpalist = {
+    'sh_ee_dd_ecm91p2':['Z/Gamma* ecm=91.188GeV to dd (Sherpa 3.0)','','','6655.04','1.0','1.0'],
+    'sh_ee_uu_ecm91p2':['Z/Gamma* ecm=91.188GeV to uu (Sherpa 3.0)','','','5215.46','1.0','1.0'],
+    'sh_ee_ss_ecm91p2':['Z/Gamma* ecm=91.188GeV to ss (Sherpa 3.0)','','','5215.46','1.0','1.0'],
+    'sh_ee_cc_ecm91p2':['Z/Gamma* ecm=91.188GeV to cc (Sherpa 3.0)','','','5215.46','1.0','1.0'],
+    'sh_ee_bb_ecm91p2':['Z/Gamma* ecm=91.188GeV to bb (Sherpa 3.0)','','','6645.46','1.0','1.0'],
+}
 
 ##Gridpack list
 ##     0          1            2                 3           4           5


### PR DESCRIPTION
# Add Herwig and Sherpa direct production

generation -> HepMC -> Delphes -> EDM4hep in a single job

## Changes

- `bin/send_herwig.py` (new): Herwig -> HepMC2 -> `DelphesHepMC2_EDM4HEP`
- `bin/send_sherpa.py` (new): Sherpa -> HepMC3 -> `DelphesHepMC3_EDM4HEP`
- `bin/run.py`: `herwig`/`sherpa` added to `--type`
- `config/param_FCCee.py`: `herwigcards_dir`, `sherpacards_dir`, `herwiglist`,
  `sherpalist`, `pre_summer2026[_training]` prodTag (pinned nightly 2026-06-06 for testing, will be updated with stable release later)
- `bin/send_stdhep.py`: Whizard `v3.1.5/` card path for `pre_summer2026`

Cards are in FCC-config branch `pre_summer2026`.

## Usage

```bash
python bin/run.py --FCCee --reco --send --type herwig -p hw_ee_bb_ecm91p2 \
    -n 100000 -N 10 --prodtag pre_summer2026 --detector IDEA --condor -q tomorrow
```
